### PR TITLE
AB#777 remove dependency to disable automatic endpoint mapping

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,10 +36,6 @@
 			<version>4.1.1</version>
 		</dependency>
 		<dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-rest</artifactId>
-        </dependency>
-		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>


### PR DESCRIPTION
removed springboot starter from dependencies to disable automatic mapping of API endpoints, locking down user information and sensitive administrative data disclosure findings. verified service builds successfully with mvn clean install, and functionality of public search portal not impacted.